### PR TITLE
Remove mobile SDK configuration identity.adidEnabled

### DIFF
--- a/extension-reference/mobile/build-your-own-extension/events/rules-engine/events-handled-by-the-rules-engine.md
+++ b/extension-reference/mobile/build-your-own-extension/events/rules-engine/events-handled-by-the-rules-engine.md
@@ -46,7 +46,6 @@ Here are the key-value pairs in this event:
 |  | global.ssl | boolean | If set to true, network requests should be dispatched via HTTPS. If false, network requests should be dispatched via HTTP. |
 | **Identity** | experienceCloud.org | string | Experience Cloud Org Identifier |
 |  | experienceCloud.server | string | Custom endpoint to be used for Visitor ID Service network requests. |
-|  | identity.adidEnabled | boolean | If set to true, indicates that the SDK should expect a call to `setAdvertisingIdentifier` . |
 | **Lifecycle** | lifecycle.backdateSessionInfo | boolean | If set to true, Analytics requests containing session info or crash events will be backdated to one second after the last hit was sent. If false, this data will be attached to the first hit of the subsequent session. |
 |  | lifecycle.sessionTimeout | number | Number of seconds since the user background the app that must pass in order for the subsequent app launch \(or resume\) to be considered a new lifecycle session. |
 | **Rules Engine** | rules.url | string\[\] | List of Rules endpoints \(represented as strings\), in order of preference. |

--- a/extension-reference/mobile/build-your-own-extension/events/sdk-core/events-dispatched-by-sdk-core.md
+++ b/extension-reference/mobile/build-your-own-extension/events/sdk-core/events-dispatched-by-sdk-core.md
@@ -30,7 +30,6 @@ Here are the key-value pairs in this event:
 |  | global.ssl | boolean | If set to `true`, network requests should be dispatched with HTTPS. If `false`, network requests should be dispatched with HTTP. |
 | **Identity** | experienceCloud.org | string | Experience Cloud Org Identifier |
 |  | experienceCloud.server | string | Custom endpoint to be used for Visitor ID Service network requests. |
-|  | identity.adidEnabled | boolean | If set to `true`, indicates that the Mobile SDK should expect a call to `setAdvertisingIdentifier`. |
 | **Lifecycle** | lifecycle.backdateSessionInfo | boolean | If set to `true`, Analytics requests that contain session info or crash events will be backdated to one second after the last hit was sent. If `false`, this data will be attached to the first hit of the subsequent session. |
 |  | lifecycle.sessionTimeout | number | Number of seconds since the user backgrounded the app, so that a  subsequent app launch \(or resume\)  will be considered a new lifecycle session. |
 | **Rules Engine** | rules.url | string\[\] | List of Rules endpoints that are represented as strings, in the order of preference. |

--- a/extension-reference/mobile/identity/configuration-keys.md
+++ b/extension-reference/mobile/identity/configuration-keys.md
@@ -6,6 +6,5 @@ The following keys are used by the Adobe Cloud Platform SDKs to configure the Id
 | :--- | :--- | :--- |
 | experienceCloud.org | string | Specifies the Experience Cloud organization ID for the ID service. |
 | experienceCloud.server | string | Optional value that allows you to override the default endpoint for the Experience Cloud Server |
-| identity.adidEnabled | boolean | If set to `true`, an advertising identifier can be set using the `setAdvertisingIdentifier` API. |
 | global.privacy | string | It set to `optedout`, the Identity extension does not store or sync identifiers. Please see the API docs for more details. |
 

--- a/extension-reference/mobile/identity/identity-methods-in-android.md
+++ b/extension-reference/mobile/identity/identity-methods-in-android.md
@@ -153,10 +153,7 @@ This API is part of the MobileCore extension. Adobe Identity extension supports 
 
 This ID is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall.
 
-Remember the following information:
-
-* If the Adobe Cloud Platform SDK is configured with `identity.adidEnabled` set to `false`, then the advertising identifier is not set or stored.
-* If the current SDK privacy status is `optedout`, then the advertising identifier is not set.
+Remember, if the current SDK privacy status is `optedout`, then the advertising identifier is not set.
 
 ### **Syntax**
 

--- a/extension-reference/mobile/identity/identity-methods-in-ios.md
+++ b/extension-reference/mobile/identity/identity-methods-in-ios.md
@@ -190,10 +190,7 @@ This API is part of the ACPCore extension. Adobe Identity extension supports the
 
 If the IDFA was set in the SDK, the IDFA will be sent in lifecycle. It can also be accessed in Signals \(Postbacks\). This ID is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall.
 
-Remember the following information:
-
-* If the Adobe Experience Cloud Platform SDKs is configured with `identity.adidEnabled` set to `false`, the advertising identifier is not set or stored.
-* If the current SDK privacy status is `optedout`, the advertising identifier is not set.
+Remember, if the current SDK privacy status is `optedout`, the advertising identifier is not set.
 
 ### **Syntax**
 


### PR DESCRIPTION
Removing the V5 mobile SDK configuration `identity.adidEnabled` from the documentation as it it no longer being used in the SDK.