### PR TITLE
Improved variable name examples. Removed exception type docs.

### DIFF
--- a/extension-reference/adobe-extensions/core-extension.md
+++ b/extension-reference/adobe-extensions/core-extension.md
@@ -328,9 +328,32 @@ The following value comparison operators are available:
 
 Specify the JavaScript variable name and value that must exist for an event to trigger an action.
 
-1. Specify the JavaScript variable name.
+1. Specify the JavaScript variable name. This variable must be available on the `window` object.
 2. Specify the variable value that must exist as a condition for the event.
 3. \(Optional\) Enable Regex if this is a regular expression.
+
+If a variable is nested within an object or array, you may use dot notation to reference the variable. 
+
+#### Example:
+
+Consider the following object on window:
+
+```
+window.dataLayer = {
+  products: [
+    {
+      name: 'shoe',
+      price: 64.99
+    },
+    {
+      name: 'shirt',
+      price: 19.99
+    }
+  ]
+};
+```
+
+To reference the price of the shirt product, you would provide the following for the variable name: `dataLayer.products.1.price`
 
 ### Engagement
 
@@ -529,284 +552,6 @@ Specify URL parameter used in the URL.
 2. Specify the value used for the URL parameter.
 3. \(Optional\) Enable Regex if this is a regular expression.
 
-## Core extension exception types
-
-This section describes the exception types available in the Core extension.
-
-### Data
-
-#### Cookie
-
-Specify the cookie name and value that can't exist for an event to trigger an action.
-
-1. Specify a cookie name.
-2. Enter the value that must not exist in the cookie if the event is to trigger an action.
-3. \(Optional\) Enable Regex if this is a regular expression.
-
-#### Cookie Opt-out
-
-Specify whether the user has opted out of cookies.
-
-Set whether the user accepts cookies.
-
-#### Custom Code
-
-Specify any custom code that must exist as a condition of the event. Use the built-in code editor to enter the custom code.
-
-1. Click Open Editor.
-2. Type the custom code.
-3. Click Save.
-
-#### Value Comparison
-
-Compares two values to determine whether this exception returns true.
-
-If you have a rule with multiple conditions, it is possible that this condition will return true, but the rule will still not fire because the other conditions evaluate as false or one of the exceptions evaluates as true.
-
-1. Provide a value.
-2. Select the operator. Refer to the list of  value comparison operators, below, for more details.
-3. \(Where required\) Select whether the comparison should be case-insensitive.                       
-4. Provide another value for the comparison.
-
-The following value comparison operators are available:
-
-**Equal:** The condition returns true if the two values are equal using a non-strict comparison \(in JavaScript, the == operator\). The values may be of any type. When typing a word like _true_, _false_, _null_, or _undefined_ into a value field, the word is compared as a string and is not be converted to its JavaScript equivalent.
-
-**Does Not Equal:** The condition returns true if the two values are not equalusing a non-strict comparison \(in JavaScript, the != operator\). The values may be of any type. When typing a word like _true_, _false_, _null_, or _undefined_ into a value field, the word is compared as a string and is not be converted to its JavaScript equivalent.
-
-**Contains:** The condition returns true if the first value contains the second value. Numbers are converted to strings. Any value other than a number or string results in the condition returning false.
-
-**Does Not Contain:** The condition returns true if the first value does not contain the second value. Numbers are converted to strings. Any value other than a number or string will result in the condition returning true.
-
-**Starts With:** The condition returns true if the first value starts with the second value. Numbers are converted to strings. Any value other than a number or string results in the condition returning false.
-
-**Does Not Start With:** The condition returns true if the first value does not start with the second value. Numbers are converted to strings. Any value other than a number or string results in the condition returning true.
-
-**Ends With:** The condition returns true if the first value ends with the second value. Numbers are converted to strings. Any value other than a number or string results in the condition returning false.
-
-**Does Not End With:** The condition returns true if the first value does not end with the second value. Numbers are converted to strings. Any value other than a number or string results in the condition returning true.
-
-**Matches Regex:** The condition returns true if the first value matches the regular expression. Numbers are converted to strings. Any value other than a number or string results in the condition returning false.
-
-**Does Not Match Regex:** The condition returns true if the first value does not match the regular expression. Numbers are converted to strings. Any value other than a number or string results in the condition returning true.
-
-**Is Less Than:** The condition returns true if the first value is less than the second value. Strings representing numbers are converted to numbers. Any value other than a number or a convertible string result in the condition returning false.
-
-**Is Less Than Or Equal To:** The condition returns true if the first value is less than or equal to the second value. Strings representing numbers are converted to numbers. Any value other than a number or a convertible string result in the condition returning false.
-
-**Is Greater Than:** The condition returns true if the first value is greater than the second value. Strings representing numbers are converted to numbers. Any value other than a number or a convertible string result in the condition returning false.
-
-**Is Greater Than Or Equal To:** The condition returns true if the first value is greater than or equal to the second value. Strings representing numbers are converted to numbers. Any value other than a number or a convertible string result in the condition returning false.
-
-**Is True:** The condition returns true if the value is a boolean with the value of true. The value you provide is not converted to a boolean if it is any other type. Any value other than a boolean with the value of true results in the condition returning false.
-
-**Is Truthy:** The condition returns true if the value is true after being converted to a boolean. See [MDN's Truthy documentation](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) for examples of truthy values.
-
-**Is False:** The condition returns true if the value is a boolean with the value of false. The value you provide is not converted to a boolean if it is any other type. Any value other than a boolean with the value of false results in the condition returning false.
-
-**Is Falsy:** The condition returns true if the value is false after being converted to a boolean. See [MDN's Falsy documentation](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) for examples of falsy values.
-
-#### Variable
-
-Specify the JavaScript variable name and value that must not exist for an event to trigger an action.
-
-1. Specify the JavaScript variable name.
-2. Specify the variable value that must not exist as a condition for the event.
-3. \(Optional\) Enable Regex if this is a regular expression.
-
-### Engagement
-
-#### Landing Page
-
-Specify the page the user must not land on to trigger the event.
-
-1. Specify the landing page.
-2. \(Optional\) Enable Regex if this is a regular expression.
-
-#### New/Returning Visitor
-
-Specify whether the visitor should not be a new visitor or a returning visitor for an event to trigger an action.
-
-Select one of the following:
-
-* New Visitor
-* Returning Visitor
-
-#### Page Views
-
-Configure the number of times the visitor must view the page to keep the action from being triggered.
-
-1. Select whether the number of page views must be greater than, equal to, or less than the specified value.
-2. Specify the number of page views that determines whether the exception is met.
-3. Configure when the page views are counted by selecting one of the following:
-   * Lifetime
-   * Current Session
-
-#### Sessions
-
-Do not trigger the action if the user's number of sessions meets the specified criteria.
-
-1. Select whether the number of sessions must be greater than, equal to, or less than the specified value.
-2. Specify the number of sessions that determines whether the condition is met.
-
-#### Time On Site
-
-Configure how long the visitor must be on the site to prevent the action from being triggered.
-
-1. Select whether the number of minutes the visitor is on the site must be greater than, equal to, or less than the specified value.
-2. Specify the number of minutes that determines whether the condition is met.
-
-#### Traffic Source
-
-Specify the source of the visitor's traffic that must be true to prevent the action from being triggered.
-
-1. Specify the traffic source.
-2. \(Optional\) Enable Regex if this is a regular expression.
-
-### Other
-
-#### Date Range
-
-Specify a date range. Choose the date and time the event occurs after, the date it occurs before, and the time zone.
-
-#### Max Frequency
-
-Specify the maximum number of times the condition returns true. You can select from the following options:
-
-* Page view
-* Sessions
-* Visitor
-* Seconds
-* Minutes
-* Days
-* Weeks
-* Months
-
-#### Sampling
-
-Specify the percentage of the time the condition returns true.
-
-### Technology
-
-#### Browser
-
-Select the browser the visitor must not use for the action to be triggered.
-
-Select one or more of the following browsers:
-
-* Chrome
-* Firefox
-* Internet Explorer/Edge
-* Internet Explorer Mobile
-* Mobile Safari
-* OmniWeb
-* Opera
-* Opera Mini
-* Opera Mobile
-* Safari
-
-#### Device Type
-
-Select the device type the visitor must not use for the action to be triggered.
-
-Select one or more of the following device types:
-
-* Android
-* Blackberry
-* Desktop
-* iPad
-* iPhone
-* iPod
-* Nokia
-* Windows Phone
-
-#### Operating System
-
-Select the operating system the visitor must not use for the action to be triggered.
-
-Select one or more of the following operating systems:
-
-* Android
-* Blackberry
-* iOS
-* Linux
-* MacOS
-* Maemo
-* Symbian OS
-* Unix
-* Windows
-
-#### Screen Resolution
-
-Select the screen resolution visitors must not use on their devices for the action to be triggered.
-
-1. Select whether the screen resolution width of the visitor's device must be greater than, equal to, or less than the specified value.
-2. Specify the number of pixels required for the screen resolution width.
-3. Select whether the screen resolution height of the visitor's device must be greater than, equal to, or less than the specified value.
-4. Specify the number of pixels required for the screen resolution height.
-
-#### Window Size
-
-Select the window size visitors must not use on their devices for the action to be triggered.
-
-1. Select whether the window size width of the visitor's device must be greater than, equal to, or less than the specified value.
-2. Specify the number of pixels required for the window size width.
-3. Select whether the window size height of the visitor's device must be greater than, equal to, or less than the specified value.
-4. Specify the number of pixels required for the window size height.
-
-### URL
-
-#### Domain
-
-Specify the visitor's domain that will prevent the action from being triggered.
-
-#### Hash
-
-Specify one or more hash patterns that must not exist in the URL.
-
-Note: Multiple hash patterns are joined by an OR.
-
-1. Specify the hash pattern.
-2. \(Optional\) Enable Regex if this is a regular expression.
-3. Add any other hash patterns.
-
-#### Path
-
-Specify one or more paths that must not exist in the URL.
-
-Note: Multiple paths are joined by an OR.
-
-1. Specify the path.
-2. \(Optional\) Enable Regex if this is a regular expression.
-3. Add any other paths.
-
-#### Protocol
-
-Specify the protocol that cannot be used in the URL.
-
-Select one of the following:
-
-* HTTP
-* HTTPS
-
-#### Subdomain
-
-Specify one or more subdomains that must not exist in the URL.
-
-Note: Multiple subdomains are joined by an OR.
-
-1. Specify the subdomain.
-2. \(Optional\) Enable Regex if this is a regular expression.
-3. Add any other subdomains.
-
-#### URL Parameter
-
-Specify URL parameter that cannot be used in the URL.
-
-1. Specify a URL parameter name.
-2. Specify the value used for the URL parameter.
-3. \(Optional\) Enable Regex if this is a regular expression.
-
 ## Core extension action types
 
 This section describes the action types available in the Core extension.
@@ -843,9 +588,7 @@ The validator used in the Launch code editor is designed to identify issues with
 
 ## Core extension data element types
 
-Data Element types are determined by the extension. There is no limit to the types that can be created.
-
-The following sections describe the types of data elements available in the Core extension. Other extensions use other types of data elements.
+This section describes the data element types available in the Core extension.
 
 ### Cookie
 
@@ -888,26 +631,30 @@ Get the value of:
 
 ### JavaScript variable
 
-Any available JavaScript object or variable can be referenced using the path field.
+Specify the JavaScript variable name. This variable must be available on the `window` object.
 
-When you have JavaScript variables, or object properties in your markup, and you want to collect those values in Launch to use with any of your extensions or rules, one way to capture those values is to use Data Elements in Launch. This way, you can refer to the Data Element throughout your Rules, and if the source of the data ever changes, you only need to change your reference to the source \(the Data Element\) in one place in Launch.
-
-For example, let's say your markup contains a JavaScript variable called `Page_Name`, like this:
-
-```markup
-<script>
-  //data layer
-  var Page_Name = "Homepage"
-</script>
-```
-
-When you create the Data Element in Launch, simply provide the path to that variable.
-
-If you use a data collector object as party of your data layer, simply use dot notation in the Path to reference the object and property you want to capture into the Data Element, like `_myData.pageName`, or `digitalData.pageName`, etc.
+If a variable is nested within an object or array, you may use dot notation to reference the variable. 
 
 #### Example:
 
-`window.document.title`
+Consider the following object on window:
+
+```
+window.dataLayer = {
+  products: [
+    {
+      name: 'shoe',
+      price: 64.99
+    },
+    {
+      name: 'shirt',
+      price: 19.99
+    }
+  ]
+};
+```
+
+To reference the price of the shirt product, you would provide the following for the variable name: `dataLayer.products.1.price`
 
 ### Local storage
 


### PR DESCRIPTION
Users were sometimes confused about how to access nested variables, especially when nested within arrays. I added examples that will hopefully make that clear.

I also noticed that there's a bit of an inconsistency between the "JavaScript Variable" data element type and the "Variable" condition. One called it "Path to variable" and the other called it "JS variable name". I made them consistent within the docs and have a pending pull request to make them consistent in the user interface: https://git.corp.adobe.com/reactor/extension-core/pull/266

Previously, the rule builder in the user interface had separate sections for specifying conditions and exceptions. I believe this was the reason we had both condition and exception sections within the documentation, even though their contents are identical (all condition types are also exception types). We recently changed the user interface so that there's just a section for conditions. When a user creates a condition, they specify a "logic type" and that logic type can be "regular" or "exception". Because of this change in treatment, I've removed the Exception Types section.