### PR TITLE
Fixed and added to the Enters Viewport event type

### DIFF
--- a/extension-reference/core-extension/README.md
+++ b/extension-reference/core-extension/README.md
@@ -166,9 +166,11 @@ See [Options](./#options), below.
 
 #### Enters Viewport
 
-Trigger the event if the user enters a specified viewport.
+Trigger the event if the specified element enters the viewport (the user's visible area of a web page).
 
 See [Options](./#options), below.
+
+You can also specify whether the rule is triggered the first time the element enters the viewport or every time the element enters the viewport.
 
 In addition, configure whether the rule is triggered immediately or after a specified number of milliseconds.
 


### PR DESCRIPTION
The option to specify whether the rule is triggered the first time the element enters the viewport or every time the element enters the viewport is new and will be in our next release of the core extension.  You may want to wait to merge this pull request until that release goes out.

