### PR TITLE
Fix `Videos` link

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -124,7 +124,7 @@ To learn more about Launch, refer to these resources:
 * [**Launch Community**](https://forums.adobe.com/community/experience-cloud/platform/launch)**:** Ask and answer questions, submit ideas, vote on the ideas of others. Log in with your Adobe ID.
 * [**Launch Webinars**](https://adobe.com/go/launchme)**:** Sign up for upcoming webinars and watch recordings of past webinars.
 * [**Developer Docs**](http://developer.adobelaunch.com/)**:** Get involved with the Launch developer community to build extensions or use the Launch APIs
-* [**Videos**](https://github.com/Adobe-Marketing-Cloud/reactor-user-docs/tree/67a59a7519514467a713016adfe46d999fe330d8/getting-started/videos.html)
+* [**Videos**](https://docs.adobelaunch.com/getting-started/videos)
 
   These videos introduce you to Launch concepts and tasks.
 


### PR DESCRIPTION
Fix `Videos` link in `Additional Resources` section